### PR TITLE
fix: hopper conflict and reload-command

### DIFF
--- a/src/main/java/me/entity303/openshulker/OpenShulker.java
+++ b/src/main/java/me/entity303/openshulker/OpenShulker.java
@@ -53,7 +53,7 @@ public final class OpenShulker extends JavaPlugin implements Listener {
         command.setTabCompleter(openShulkerCommand);
     }
 
-    private void InitializeConfig() {
+    public void InitializeConfig() {
         this.saveDefaultConfig();
 
         this.reloadConfig();
@@ -92,10 +92,6 @@ public final class OpenShulker extends JavaPlugin implements Listener {
         this._allowContainerOpen = this.getConfig().getBoolean("OpenMethods.AllowContainerOpen");
         this._allowEnderChestOpen = this.getConfig().getBoolean("OpenMethods.AllowEnderChestOpen");
         this._allowHandOpen = this.getConfig().getBoolean("OpenMethods.AllowHandOpen");
-    }
-
-    public void reloadCfg(){
-        this.InitializeConfig();
     }
 
     public ShulkerActions GetShulkerActions() {

--- a/src/main/java/me/entity303/openshulker/OpenShulker.java
+++ b/src/main/java/me/entity303/openshulker/OpenShulker.java
@@ -94,6 +94,10 @@ public final class OpenShulker extends JavaPlugin implements Listener {
         this._allowHandOpen = this.getConfig().getBoolean("OpenMethods.AllowHandOpen");
     }
 
+    public void reloadCfg(){
+        this.InitializeConfig();
+    }
+
     public ShulkerActions GetShulkerActions() {
         return this._shulkerActions;
     }

--- a/src/main/java/me/entity303/openshulker/commands/OpenShulkerCommand.java
+++ b/src/main/java/me/entity303/openshulker/commands/OpenShulkerCommand.java
@@ -34,7 +34,7 @@ public class OpenShulkerCommand implements TabExecutor {
         }
 
         if (args[0].equalsIgnoreCase("reload")) {
-            this._openShulker.reloadCfg();
+            this._openShulker.InitializeConfig();
             commandSender.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', this._openShulker.getConfig()
                                                                                                             .getString(
                                                                                                                     "Messages.OpenShulkerCommand.Reloaded")

--- a/src/main/java/me/entity303/openshulker/commands/OpenShulkerCommand.java
+++ b/src/main/java/me/entity303/openshulker/commands/OpenShulkerCommand.java
@@ -34,7 +34,7 @@ public class OpenShulkerCommand implements TabExecutor {
         }
 
         if (args[0].equalsIgnoreCase("reload")) {
-            this._openShulker.reloadConfig();
+            this._openShulker.reloadCfg();
             commandSender.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', this._openShulker.getConfig()
                                                                                                             .getString(
                                                                                                                     "Messages.OpenShulkerCommand.Reloaded")

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerDupeListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerDupeListener.java
@@ -126,7 +126,7 @@ public class ShulkerDupeListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void OnDupedShulkerPlace(PlayerInteractEvent event) {
-        ItemStack itemStack = event.getHand() != null? event.getPlayer().getInventory().getItem(event.getHand()) : event.getItem();
+        ItemStack itemStack = event.getHand() != null ? event.getPlayer().getInventory().getItem(event.getHand()) : event.getItem();
 
         if (itemStack == null) return;
 
@@ -150,7 +150,10 @@ public class ShulkerDupeListener implements Listener {
 
         if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox((Player) event.getWhoClicked())) return;
 
-        if (!this._openShulker.GetShulkerActions().IsOpenShulker(clickedItemStack)) return;
+        //Make operator can modify shulkerbox's NBT to reset it, which can solve some strange bugs caused by PersistentDataContainer
+        //Like player has closed shulkerbox but the dataContainer still contains player's UUID so that player can't interact with the shulkerbox
+        if (!this._openShulker.GetShulkerActions().IsOpenShulker(clickedItemStack) || event.getWhoClicked().isOp())
+            return;
 
         if (event.isRightClick() && event.isShiftClick()) return;
 

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -18,6 +18,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -42,6 +43,9 @@ public class ShulkerOpenCloseListener implements Listener {
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
         if (!event.getPlayer().isSneaking()) return;
+
+        //Don't open shulkerbox when interact with hopper
+        if (event.getClickedBlock() != null && event.getClickedBlock().getType() == Material.HOPPER) return;
 
         event.setCancelled(this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(event.getPlayer()));
     }


### PR DESCRIPTION
fix hopper conflict when shift+rightclick;
fix reload-command can't reload config correctly.