### PR TITLE
fix shulkerbox placement on hopper

### DIFF
--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -40,7 +40,7 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (event.getHand() != EquipmentSlot.HAND) return;
 
-        if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getAction() != Action.RIGHT_CLICK_AIR) return;
 
         if (!event.getPlayer().isSneaking()) return;
 


### PR DESCRIPTION
the shulker will only open on a click in the air. no longer on interactions with blocks. You can now open chests with the shulker in the hand and place the shulker even while sneaking