### PR TITLE
Add Minecraft 26.2 support, item input, and optional ChestSort/WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,18 @@ OpenSound: "BLOCK_SHULKER_BOX_OPEN"
 # Sound for closing a Shulker
 CloseSound: "BLOCK_SHULKER_BOX_CLOSE"
 Hooks:
+  # If ChestSort is installed and this is true, opened shulker inventories are marked as unsortable.
   ChestSort: true
+  # If WorldGuard is installed and this is true, shulkers inside protected containers can only be used where the player has container access.
   WorldGuard: true
+# Ingame admin commands:
+# /openshulker reload - reloads this config
+# /openshulker hooks - shows if ChestSort/WorldGuard hooks are enabled and loaded
 Messages:
   Prefix: "&8[&2OpenShulker&8] &7"
-  CannotBreakContainer: "§cYou cannot break this container, since there's an opened shulker in it"
+  CannotBreakContainer: "&cYou cannot break this container, since there's an opened shulker in it"
   OpenShulkerCommand:
-    Syntax: "&cSyntax: &4/<LABEL> <Reload>"
+    Syntax: "&cSyntax: &4/<LABEL> <Reload|Hooks>"
     Reloaded: "The plugin was reloaded!"
 ```
 
@@ -41,6 +46,7 @@ Messages:
 # Commands
 
 - `openshulker reload`
+- `openshulker hooks`
 
 # Support
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenShulker
 
-OpenShulker is a plugin for 1.14 to 1.20.1 that makes Shulkerboxes more useful.
+OpenShulker is a plugin for 1.14 to 26.2 that makes Shulkerboxes more useful.
 
 You can open a Shulker by Shift-Rightclicking it in your hand or Inventory.
 
@@ -21,6 +21,9 @@ You can download it on spigotmc: [OpenShulker](https://www.spigotmc.org/resource
 OpenSound: "BLOCK_SHULKER_BOX_OPEN"
 # Sound for closing a Shulker
 CloseSound: "BLOCK_SHULKER_BOX_CLOSE"
+Hooks:
+  ChestSort: true
+  WorldGuard: true
 Messages:
   Prefix: "&8[&2OpenShulker&8] &7"
   CannotBreakContainer: "§cYou cannot break this container, since there's an opened shulker in it"
@@ -47,7 +50,4 @@ Github: [Issues Page](https://github.com/Test-Account666/OpenShulker/issues)
 
 # Todo
 
-- Add ability to input items by right clicking an item on/with a shulker box
-- Add ChestSort Hook
-- Add WorldGuard Hook
 - Add update checker

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <paper.version>26.2.build.31-alpha</paper.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -61,13 +62,23 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>enginehub-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>${paper.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.17</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.entity303</groupId>
     <artifactId>OpenShulker</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>OpenShulker</name>

--- a/src/main/java/me/entity303/openshulker/OpenShulker.java
+++ b/src/main/java/me/entity303/openshulker/OpenShulker.java
@@ -82,7 +82,7 @@ public final class OpenShulker extends JavaPlugin implements Listener {
         } catch (Throwable ignored) {
             if (closeSound == null) {
                 Bukkit.getLogger().severe("You did not specify CloseSound, using default");
-                this.getConfig().set("OpenSound", "BLOCK_SHULKER_BOX_CLOSE");
+                this.getConfig().set("CloseSound", "BLOCK_SHULKER_BOX_CLOSE");
                 this.saveConfig();
                 this.reloadConfig();
             } else Bukkit.getLogger()

--- a/src/main/java/me/entity303/openshulker/OpenShulker.java
+++ b/src/main/java/me/entity303/openshulker/OpenShulker.java
@@ -1,6 +1,7 @@
 package me.entity303.openshulker;
 
 import me.entity303.openshulker.commands.OpenShulkerCommand;
+import me.entity303.openshulker.hooks.ChestSortHook;
 import me.entity303.openshulker.listener.ShulkerDupeListener;
 import me.entity303.openshulker.listener.ShulkerOpenCloseListener;
 import me.entity303.openshulker.listener.ShulkerReadOnlyListener;
@@ -19,6 +20,7 @@ public final class OpenShulker extends JavaPlugin implements Listener {
     public boolean _allowEnderChestOpen = true;
     public boolean _allowHandOpen = true;
     public boolean _hookChestSort = true;
+    public boolean _debugChestSort = false;
     public boolean _hookWorldGuard = true;
     private ShulkerActions _shulkerActions;
 
@@ -53,12 +55,16 @@ public final class OpenShulker extends JavaPlugin implements Listener {
 
         command.setExecutor(openShulkerCommand);
         command.setTabCompleter(openShulkerCommand);
+
+        this.LogHookStatus();
     }
 
     public void InitializeConfig() {
         this.saveDefaultConfig();
 
         this.reloadConfig();
+
+        this.AddConfigDefaults();
 
         String openSound = this.getConfig().getString("OpenSound");
 
@@ -95,7 +101,55 @@ public final class OpenShulker extends JavaPlugin implements Listener {
         this._allowEnderChestOpen = this.getConfig().getBoolean("OpenMethods.AllowEnderChestOpen");
         this._allowHandOpen = this.getConfig().getBoolean("OpenMethods.AllowHandOpen");
         this._hookChestSort = this.getConfig().getBoolean("Hooks.ChestSort", true);
+        this._debugChestSort = this.getConfig().getBoolean("Hooks.ChestSortDebug", false);
         this._hookWorldGuard = this.getConfig().getBoolean("Hooks.WorldGuard", true);
+    }
+
+    private void AddConfigDefaults() {
+        boolean changed = false;
+
+        changed |= this.AddConfigDefault("OpenMethods.AllowInventoryOpen", true);
+        changed |= this.AddConfigDefault("OpenMethods.AllowContainerOpen", true);
+        changed |= this.AddConfigDefault("OpenMethods.AllowEnderChestOpen", true);
+        changed |= this.AddConfigDefault("OpenMethods.AllowHandOpen", true);
+        changed |= this.AddConfigDefault("WaitSecondsBeforeOpen", 0);
+        changed |= this.AddConfigDefault("OpenSound", "BLOCK_SHULKER_BOX_OPEN");
+        changed |= this.AddConfigDefault("CloseSound", "BLOCK_SHULKER_BOX_CLOSE");
+        changed |= this.AddConfigDefault("Hooks.ChestSort", true);
+        changed |= this.AddConfigDefault("Hooks.ChestSortDebug", false);
+        changed |= this.AddConfigDefault("Hooks.WorldGuard", true);
+        changed |= this.AddConfigDefault("Messages.Prefix", "&8[&2OpenShulker&8] &7");
+        changed |= this.AddConfigDefault("Messages.CannotBreakContainer", "&cYou cannot break this container, since there's an opened shulker in it");
+        changed |= this.AddConfigDefault("Messages.OpenShulkerCommand.Syntax", "&cSyntax: &4/<LABEL> <Reload|Hooks>");
+        changed |= this.AddConfigDefault("Messages.OpenShulkerCommand.Reloaded", "The plugin was reloaded!");
+
+        if (!changed) return;
+
+        this.getConfig().options().copyDefaults(true);
+        this.saveConfig();
+        this.reloadConfig();
+    }
+
+    private boolean AddConfigDefault(String path, Object value) {
+        boolean missing = !this.getConfig().isSet(path);
+        this.getConfig().addDefault(path, value);
+        return missing;
+    }
+
+    private void LogHookStatus() {
+        this.getLogger().info("ChestSort hook: " + this.FormatHookStatus(this._hookChestSort, ChestSortHook.IsLoaded()));
+        this.getLogger().info("WorldGuard hook: " +
+                              this.FormatHookStatus(this._hookWorldGuard, Bukkit.getPluginManager().getPlugin("WorldGuard") != null));
+
+        if (this._hookChestSort && this._debugChestSort && ChestSortHook.IsLoaded() && !ChestSortHook.IsApiAvailable()) {
+            this.getLogger().warning("ChestSort is loaded, but OpenShulker could not find a supported ChestSortAPI#setUnsortable method.");
+        }
+    }
+
+    private String FormatHookStatus(boolean enabledInConfig, boolean pluginLoaded) {
+        if (!enabledInConfig) return "disabled in config";
+        if (!pluginLoaded) return "enabled in config, plugin not loaded";
+        return "enabled and plugin loaded";
     }
 
     public ShulkerActions GetShulkerActions() {

--- a/src/main/java/me/entity303/openshulker/OpenShulker.java
+++ b/src/main/java/me/entity303/openshulker/OpenShulker.java
@@ -26,6 +26,8 @@ public final class OpenShulker extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
+        if (this._shulkerActions == null) return;
+
         for (Player all : Bukkit.getOnlinePlayers()) {
             if (!this._shulkerActions.HasOpenShulkerBox(all)) continue;
 

--- a/src/main/java/me/entity303/openshulker/OpenShulker.java
+++ b/src/main/java/me/entity303/openshulker/OpenShulker.java
@@ -18,6 +18,8 @@ public final class OpenShulker extends JavaPlugin implements Listener {
     public boolean _allowContainerOpen = true;
     public boolean _allowEnderChestOpen = true;
     public boolean _allowHandOpen = true;
+    public boolean _hookChestSort = true;
+    public boolean _hookWorldGuard = true;
     private ShulkerActions _shulkerActions;
 
     @Override
@@ -92,6 +94,8 @@ public final class OpenShulker extends JavaPlugin implements Listener {
         this._allowContainerOpen = this.getConfig().getBoolean("OpenMethods.AllowContainerOpen");
         this._allowEnderChestOpen = this.getConfig().getBoolean("OpenMethods.AllowEnderChestOpen");
         this._allowHandOpen = this.getConfig().getBoolean("OpenMethods.AllowHandOpen");
+        this._hookChestSort = this.getConfig().getBoolean("Hooks.ChestSort", true);
+        this._hookWorldGuard = this.getConfig().getBoolean("Hooks.WorldGuard", true);
     }
 
     public ShulkerActions GetShulkerActions() {

--- a/src/main/java/me/entity303/openshulker/commands/OpenShulkerCommand.java
+++ b/src/main/java/me/entity303/openshulker/commands/OpenShulkerCommand.java
@@ -1,6 +1,8 @@
 package me.entity303.openshulker.commands;
 
 import me.entity303.openshulker.OpenShulker;
+import me.entity303.openshulker.hooks.ChestSortHook;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -9,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class OpenShulkerCommand implements TabExecutor {
@@ -42,6 +43,14 @@ public class OpenShulkerCommand implements TabExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("hooks")) {
+            commandSender.sendMessage(prefix + "ChestSort hook: " + this.FormatHookStatus(this._openShulker._hookChestSort, ChestSortHook.IsLoaded()));
+            commandSender.sendMessage(prefix + "WorldGuard hook: " +
+                                      this.FormatHookStatus(this._openShulker._hookWorldGuard,
+                                                            Bukkit.getPluginManager().getPlugin("WorldGuard") != null));
+            return true;
+        }
+
         commandSender.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', this._openShulker.getConfig()
                                                                                                         .getString("Messages.OpenShulkerCommand.Syntax")
                                                                                                         .replace("<LABEL>", label)));
@@ -51,8 +60,19 @@ public class OpenShulkerCommand implements TabExecutor {
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s,
                                                 @NotNull String[] args) {
-        if (args.length == 1) return Collections.singletonList("reload");
+        if (args.length == 1) {
+            List<String> completions = new ArrayList<>();
+            completions.add("reload");
+            completions.add("hooks");
+            return completions;
+        }
 
         return new ArrayList<>();
+    }
+
+    private String FormatHookStatus(boolean enabledInConfig, boolean pluginLoaded) {
+        if (!enabledInConfig) return ChatColor.RED + "disabled in config";
+        if (!pluginLoaded) return ChatColor.YELLOW + "enabled in config, plugin not loaded";
+        return ChatColor.GREEN + "enabled";
     }
 }

--- a/src/main/java/me/entity303/openshulker/hooks/ChestSortHook.java
+++ b/src/main/java/me/entity303/openshulker/hooks/ChestSortHook.java
@@ -4,20 +4,89 @@ import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public final class ChestSortHook {
+    private static final String[] API_CLASSES = {
+            "de.jeff_media.chestsort.api.ChestSortAPI",
+            "de.jeff_media.chestsort.ChestSortAPI"
+    };
+    private static boolean _warnedMissingApi = false;
+
     private ChestSortHook() {
     }
 
-    public static void SetUnsortable(Inventory inventory) {
-        if (Bukkit.getPluginManager().getPlugin("ChestSort") == null) return;
+    public static void SetUnsortable(Inventory inventory, boolean debug) {
+        if (!IsLoaded()) return;
+        if (inventory == null) return;
+
+        for (String apiClass : API_CLASSES) {
+            if (TrySetUnsortable(apiClass, inventory)) return;
+        }
+
+        if (debug && !_warnedMissingApi) {
+            Bukkit.getLogger().warning("[OpenShulker] ChestSort is loaded, but no supported ChestSortAPI#setUnsortable method was found.");
+            _warnedMissingApi = true;
+        }
+    }
+
+    public static boolean IsLoaded() {
+        return Bukkit.getPluginManager().getPlugin("ChestSort") != null;
+    }
+
+    public static boolean IsApiAvailable() {
+        if (!IsLoaded()) return false;
+
+        for (String apiClass : API_CLASSES) {
+            try {
+                Class<?> chestSortApi = Class.forName(apiClass);
+                if (FindUnsortableMethod(chestSortApi) != null) return true;
+            } catch (Throwable ignored) {
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean TrySetUnsortable(String apiClass, Inventory inventory) {
+        try {
+            Class<?> chestSortApi = Class.forName(apiClass);
+
+            try {
+                Method setUnsortable = chestSortApi.getMethod("setUnsortable", Inventory.class);
+                setUnsortable.invoke(null, inventory);
+                return true;
+            } catch (NoSuchMethodException ignored) {
+                return TryMatchingUnsortableMethod(chestSortApi, inventory);
+            }
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private static boolean TryMatchingUnsortableMethod(Class<?> chestSortApi, Inventory inventory) {
+        Method method = FindUnsortableMethod(chestSortApi);
+
+        if (method == null) return false;
 
         try {
-            Class<?> chestSortApi = Class.forName("de.jeff_media.chestsort.api.ChestSortAPI");
-            Method setUnsortable = chestSortApi.getMethod("setUnsortable", Inventory.class);
-            setUnsortable.invoke(null, inventory);
+            method.invoke(null, inventory);
+            return true;
         } catch (Throwable ignored) {
-            // ChestSort is optional and older builds may not expose the API.
+            return false;
         }
+    }
+
+    private static Method FindUnsortableMethod(Class<?> chestSortApi) {
+        for (Method method : chestSortApi.getMethods()) {
+            if (!Modifier.isStatic(method.getModifiers())) continue;
+            if (!method.getName().toLowerCase().contains("unsort")) continue;
+            if (method.getParameterTypes().length != 1) continue;
+            if (!method.getParameterTypes()[0].isAssignableFrom(Inventory.class)) continue;
+
+            return method;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/me/entity303/openshulker/hooks/ChestSortHook.java
+++ b/src/main/java/me/entity303/openshulker/hooks/ChestSortHook.java
@@ -1,0 +1,23 @@
+package me.entity303.openshulker.hooks;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.Inventory;
+
+import java.lang.reflect.Method;
+
+public final class ChestSortHook {
+    private ChestSortHook() {
+    }
+
+    public static void SetUnsortable(Inventory inventory) {
+        if (Bukkit.getPluginManager().getPlugin("ChestSort") == null) return;
+
+        try {
+            Class<?> chestSortApi = Class.forName("de.jeff_media.chestsort.api.ChestSortAPI");
+            Method setUnsortable = chestSortApi.getMethod("setUnsortable", Inventory.class);
+            setUnsortable.invoke(null, inventory);
+        } catch (Throwable ignored) {
+            // ChestSort is optional and older builds may not expose the API.
+        }
+    }
+}

--- a/src/main/java/me/entity303/openshulker/hooks/WorldGuardHook.java
+++ b/src/main/java/me/entity303/openshulker/hooks/WorldGuardHook.java
@@ -1,0 +1,37 @@
+package me.entity303.openshulker.hooks;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public final class WorldGuardHook {
+    private WorldGuardHook() {
+    }
+
+    public static boolean CanBuild(Player player, Location location) {
+        if (Bukkit.getPluginManager().getPlugin("WorldGuard") == null) return true;
+        if (location == null || location.getWorld() == null) return true;
+
+        try {
+            LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+
+            if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, BukkitAdapter.adapt(location.getWorld()))) {
+                return true;
+            }
+
+            RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+            RegionQuery query = container.createQuery();
+
+            return query.testState(BukkitAdapter.adapt(location), localPlayer, Flags.BUILD);
+        } catch (Throwable ignored) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/me/entity303/openshulker/hooks/WorldGuardHook.java
+++ b/src/main/java/me/entity303/openshulker/hooks/WorldGuardHook.java
@@ -15,7 +15,7 @@ public final class WorldGuardHook {
     private WorldGuardHook() {
     }
 
-    public static boolean CanBuild(Player player, Location location) {
+    public static boolean CanAccessContainer(Player player, Location location) {
         if (Bukkit.getPluginManager().getPlugin("WorldGuard") == null) return true;
         if (location == null || location.getWorld() == null) return true;
 
@@ -29,7 +29,7 @@ public final class WorldGuardHook {
             RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
             RegionQuery query = container.createQuery();
 
-            return query.testState(BukkitAdapter.adapt(location), localPlayer, Flags.BUILD);
+            return query.testState(BukkitAdapter.adapt(location), localPlayer, Flags.CHEST_ACCESS, Flags.INTERACT);
         } catch (Throwable ignored) {
             return true;
         }

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerDupeListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerDupeListener.java
@@ -65,6 +65,8 @@ public class ShulkerDupeListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void OnCraft(CraftItemEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+
         if (!this.HandleEvent(event, (Player) event.getWhoClicked())) return;
 
         event.setResult(Event.Result.DENY);
@@ -138,6 +140,8 @@ public class ShulkerDupeListener implements Listener {
 
     @EventHandler
     public void OnInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+
         int slot = event.getSlot();
 
         if (event.getClickedInventory() == null) return;
@@ -148,11 +152,13 @@ public class ShulkerDupeListener implements Listener {
 
         if (clickedItemStack.getType() == Material.AIR) return;
 
-        if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox((Player) event.getWhoClicked())) return;
+        Player player = (Player) event.getWhoClicked();
+
+        if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox(player)) return;
 
         //Make operator can modify shulkerbox's NBT to reset it, which can solve some strange bugs caused by PersistentDataContainer
         //Like player has closed shulkerbox but the dataContainer still contains player's UUID so that player can't interact with the shulkerbox
-        if (!this._openShulker.GetShulkerActions().IsOpenShulker(clickedItemStack) || event.getWhoClicked().isOp())
+        if (!this._openShulker.GetShulkerActions().IsOpenShulker(clickedItemStack) || player.isOp())
             return;
 
         if (event.isRightClick() && event.isShiftClick()) return;
@@ -162,6 +168,8 @@ public class ShulkerDupeListener implements Listener {
 
     @EventHandler
     public void OnInventoryClick2(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+
         int slot = event.getSlot();
 
         if (event.getClickedInventory() == null) return;
@@ -172,7 +180,9 @@ public class ShulkerDupeListener implements Listener {
 
         if (clickedItemStack.getType() == Material.AIR) return;
 
-        if (this._openShulker.GetShulkerActions().HasOpenShulkerBox((Player) event.getWhoClicked())) return;
+        Player player = (Player) event.getWhoClicked();
+
+        if (this._openShulker.GetShulkerActions().HasOpenShulkerBox(player)) return;
 
         if (!this._openShulker.GetShulkerActions().IsOpenShulker(clickedItemStack)) return;
 

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -1,6 +1,7 @@
 package me.entity303.openshulker.listener;
 
 import me.entity303.openshulker.OpenShulker;
+import me.entity303.openshulker.hooks.ChestSortHook;
 import me.entity303.openshulker.hooks.WorldGuardHook;
 import me.entity303.openshulker.util.SchedulerUtil;
 import org.bukkit.Location;
@@ -122,7 +123,10 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (location == null) return;
 
-        if (!this.CanUseInventoryLocation(player, location)) return;
+        if (!this.CanUseInventoryLocation(player, location)) {
+            event.setCancelled(true);
+            return;
+        }
 
         boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(player, clickedItemStack, location);
 
@@ -141,7 +145,10 @@ public class ShulkerOpenCloseListener implements Listener {
 
         Location location = event.getClickedInventory().getLocation();
 
-        if (!this.CanUseInventoryLocation(player, location)) return false;
+        if (!this.CanUseInventoryLocation(player, location)) {
+            event.setCancelled(true);
+            return true;
+        }
 
         if (this._openShulker.GetShulkerActions().CanInputIntoShulkerBox(player, clickedItemStack, cursorItemStack)) {
             ItemStack leftover = this._openShulker.GetShulkerActions().InputItemIntoShulkerBox(clickedItemStack, cursorItemStack);
@@ -170,7 +177,7 @@ public class ShulkerOpenCloseListener implements Listener {
         if (location == null) return true;
 
         try {
-            return WorldGuardHook.CanBuild(player, location);
+            return WorldGuardHook.CanAccessContainer(player, location);
         } catch (Throwable ignored) {
             return true;
         }
@@ -213,6 +220,9 @@ public class ShulkerOpenCloseListener implements Listener {
                 if (container.getLocation().distance(player.getLocation()) > 4) return;
 
                 player.openInventory(container.getInventory());
+                if (this._openShulker._hookChestSort) {
+                    ChestSortHook.SetUnsortable(player.getOpenInventory().getTopInventory(), this._openShulker._debugChestSort);
+                }
                 return;
             }
 

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -143,14 +143,20 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (cursorItemStack.getType() == Material.AIR) return false;
 
-        Location location = event.getClickedInventory().getLocation();
+        boolean inputCursorIntoClicked = this._openShulker.GetShulkerActions()
+                                                          .CanInputIntoShulkerBox(player, clickedItemStack, cursorItemStack);
+        boolean inputClickedIntoCursor = this._openShulker.GetShulkerActions()
+                                                          .CanInputIntoShulkerBox(player, cursorItemStack, clickedItemStack);
 
+        if (!inputCursorIntoClicked && !inputClickedIntoCursor) return false;
+
+        Location location = event.getClickedInventory().getLocation();
         if (!this.CanUseInventoryLocation(player, location)) {
             event.setCancelled(true);
             return true;
         }
 
-        if (this._openShulker.GetShulkerActions().CanInputIntoShulkerBox(player, clickedItemStack, cursorItemStack)) {
+        if (inputCursorIntoClicked) {
             ItemStack leftover = this._openShulker.GetShulkerActions().InputItemIntoShulkerBox(clickedItemStack, cursorItemStack);
 
             event.getClickedInventory().setItem(clickedSlot, clickedItemStack);
@@ -159,7 +165,7 @@ public class ShulkerOpenCloseListener implements Listener {
             return true;
         }
 
-        if (this._openShulker.GetShulkerActions().CanInputIntoShulkerBox(player, cursorItemStack, clickedItemStack)) {
+        if (inputClickedIntoCursor) {
             ItemStack leftover = this._openShulker.GetShulkerActions().InputItemIntoShulkerBox(cursorItemStack, clickedItemStack);
 
             event.setCursor(cursorItemStack);
@@ -190,7 +196,7 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (potentiallyClickedItem == null) return false;
 
-        return potentiallyClickedItem == clickedItemStack || potentiallyClickedItem.equals(clickedItemStack);
+        return potentiallyClickedItem.isSimilar(clickedItemStack);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -2,7 +2,7 @@ package me.entity303.openshulker.listener;
 
 import me.entity303.openshulker.OpenShulker;
 import me.entity303.openshulker.hooks.WorldGuardHook;
-import org.bukkit.Bukkit;
+import me.entity303.openshulker.util.SchedulerUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Container;
@@ -70,10 +70,24 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (!event.isShiftClick()) return;
 
+        if (event.getCursor() != null && event.getCursor().getType() != Material.AIR) return;
+
         if (event.getClickedInventory() == event.getWhoClicked().getInventory()) {
             if (!this._openShulker._allowInventoryOpen) return;
 
             if (event.getView().getTopInventory().getType() == InventoryType.SHULKER_BOX) {
+                if (this._openShulker.GetShulkerActions().IsOpenShulker(clickedItemStack, player)) {
+                    boolean enderChest = this._openShulker.GetShulkerActions().HasOpenShulkerInEnderChest(player);
+
+                    Container container = this._openShulker.GetShulkerActions().GetShulkerHoldingContainer(player);
+
+                    this._openShulker.GetShulkerActions().SaveShulkerBox(clickedItemStack, event.getView().getTopInventory(), player);
+
+                    event.setCancelled(true);
+                    this.ReopenInventory(enderChest, container, player);
+                    return;
+                }
+
                 if (this._openShulker.GetShulkerActions().HasOpenShulkerBox(player)) {
                     ItemStack shulkerBox = this._openShulker.GetShulkerActions().SearchShulkerBox(player);
 
@@ -192,7 +206,7 @@ public class ShulkerOpenCloseListener implements Listener {
     private void ReopenInventory(boolean enderChest, Container container, HumanEntity player) {
         player.closeInventory();
 
-        Bukkit.getScheduler().runTaskLater(this._openShulker, () -> {
+        SchedulerUtil.RunEntityLater(this._openShulker, player, () -> {
             if (container != null) {
                 if (container.getWorld() != player.getWorld()) return;
 
@@ -202,9 +216,9 @@ public class ShulkerOpenCloseListener implements Listener {
                 return;
             }
 
-            if (!enderChest) return;
-
-            player.openInventory(player.getEnderChest());
+            if (enderChest) {
+                player.openInventory(player.getEnderChest());
+            }
         }, 1L);
     }
 

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -1,6 +1,7 @@
 package me.entity303.openshulker.listener;
 
 import me.entity303.openshulker.OpenShulker;
+import me.entity303.openshulker.hooks.WorldGuardHook;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -47,12 +48,16 @@ public class ShulkerOpenCloseListener implements Listener {
         //Don't open shulkerbox when interact with hopper
         if (event.getClickedBlock() != null && event.getClickedBlock().getType() == Material.HOPPER) return;
 
-        event.setCancelled(this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(event.getPlayer()));
+        if (this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(event.getPlayer())) event.setCancelled(true);
     }
 
     @EventHandler(ignoreCancelled = true)
     public void OnShulkerOpenAlternative(InventoryClickEvent event) {
-        if (!event.getWhoClicked().hasPermission("openshulker.use")) return;
+        if (!(event.getWhoClicked() instanceof Player)) return;
+
+        Player player = (Player) event.getWhoClicked();
+
+        if (!player.hasPermission("openshulker.use")) return;
 
         if (event.getClickedInventory() == null) return;
 
@@ -64,6 +69,8 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (clickedItemStack.getType() == Material.AIR) return;
 
+        if (this.HandleShulkerItemInput(event, player, clickedItemStack, clickedSlot)) return;
+
         if (!clickedItemStack.getType().name().contains(Material.SHULKER_BOX.name())) return;
 
         if (!event.isRightClick()) return;
@@ -74,17 +81,17 @@ public class ShulkerOpenCloseListener implements Listener {
             if (!this._openShulker._allowInventoryOpen) return;
 
             if (event.getView().getTopInventory().getType() == InventoryType.SHULKER_BOX) {
-                if (this._openShulker.GetShulkerActions().HasOpenShulkerBox((Player) event.getWhoClicked())) {
-                    ItemStack shulkerBox = this._openShulker.GetShulkerActions().SearchShulkerBox((Player) event.getWhoClicked());
+                if (this._openShulker.GetShulkerActions().HasOpenShulkerBox(player)) {
+                    ItemStack shulkerBox = this._openShulker.GetShulkerActions().SearchShulkerBox(player);
 
-                    this._openShulker.GetShulkerActions().SaveShulkerBox(shulkerBox, event.getView().getTopInventory(), (Player) event.getWhoClicked());
+                    this._openShulker.GetShulkerActions().SaveShulkerBox(shulkerBox, event.getView().getTopInventory(), player);
                 }
 
                 //Close inventory to prevent overriding open shulker contents
                 event.getWhoClicked().closeInventory();
             }
 
-            boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox((Player) event.getWhoClicked(), clickedItemStack);
+            boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(player, clickedItemStack);
 
             if (!open) return;
             event.setCancelled(true);
@@ -93,9 +100,9 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (event.getClickedInventory().getType() == InventoryType.ENDER_CHEST) {
             if (!this._openShulker._allowEnderChestOpen) return;
-            if (!this.IsOwnerOfEnderChest((Player) event.getWhoClicked(), clickedItemStack, clickedSlot)) return;
+            if (!this.IsOwnerOfEnderChest(player, clickedItemStack, clickedSlot)) return;
 
-            boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox((Player) event.getWhoClicked(), clickedItemStack, true);
+            boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(player, clickedItemStack, true);
 
             if (!open) return;
             event.setCancelled(true);
@@ -108,10 +115,58 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (location == null) return;
 
-        boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox((Player) event.getWhoClicked(), clickedItemStack, location);
+        if (!this.CanUseInventoryLocation(player, location)) return;
+
+        boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(player, clickedItemStack, location);
 
         if (!open) return;
         event.setCancelled(true);
+    }
+
+    private boolean HandleShulkerItemInput(InventoryClickEvent event, Player player, ItemStack clickedItemStack, int clickedSlot) {
+        if (!event.isRightClick()) return false;
+
+        ItemStack cursorItemStack = event.getCursor();
+
+        if (cursorItemStack == null) return false;
+
+        if (cursorItemStack.getType() == Material.AIR) return false;
+
+        Location location = event.getClickedInventory().getLocation();
+
+        if (!this.CanUseInventoryLocation(player, location)) return false;
+
+        if (this._openShulker.GetShulkerActions().CanInputIntoShulkerBox(player, clickedItemStack, cursorItemStack)) {
+            ItemStack leftover = this._openShulker.GetShulkerActions().InputItemIntoShulkerBox(clickedItemStack, cursorItemStack);
+
+            event.getClickedInventory().setItem(clickedSlot, clickedItemStack);
+            event.setCursor(leftover);
+            event.setCancelled(true);
+            return true;
+        }
+
+        if (this._openShulker.GetShulkerActions().CanInputIntoShulkerBox(player, cursorItemStack, clickedItemStack)) {
+            ItemStack leftover = this._openShulker.GetShulkerActions().InputItemIntoShulkerBox(cursorItemStack, clickedItemStack);
+
+            event.setCursor(cursorItemStack);
+            event.getClickedInventory().setItem(clickedSlot, leftover);
+            event.setCancelled(true);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean CanUseInventoryLocation(Player player, Location location) {
+        if (!this._openShulker._hookWorldGuard) return true;
+
+        if (location == null) return true;
+
+        try {
+            return WorldGuardHook.CanBuild(player, location);
+        } catch (Throwable ignored) {
+            return true;
+        }
     }
 
     //Awful code, I know, but I don't see a better way

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerOpenCloseListener.java
@@ -5,7 +5,6 @@ import me.entity303.openshulker.hooks.WorldGuardHook;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.Container;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -21,18 +20,12 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 
 public class ShulkerOpenCloseListener implements Listener {
     private final OpenShulker _openShulker;
-    private final NamespacedKey _clickedShulkerKey;
 
     public ShulkerOpenCloseListener(OpenShulker openShulker) {
         this._openShulker = openShulker;
-
-        this._clickedShulkerKey = new NamespacedKey(this._openShulker, "clickedshulker");
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -100,7 +93,7 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (event.getClickedInventory().getType() == InventoryType.ENDER_CHEST) {
             if (!this._openShulker._allowEnderChestOpen) return;
-            if (!this.IsOwnerOfEnderChest(player, clickedItemStack, clickedSlot)) return;
+            if (!this.IsOwnerOfEnderChest(player, event.getClickedInventory(), clickedItemStack, clickedSlot)) return;
 
             boolean open = this._openShulker.GetShulkerActions().AttemptToOpenShulkerBox(player, clickedItemStack, true);
 
@@ -169,43 +162,14 @@ public class ShulkerOpenCloseListener implements Listener {
         }
     }
 
-    //Awful code, I know, but I don't see a better way
-    private boolean IsOwnerOfEnderChest(Player player, ItemStack clickedItemStack, int clickedSlot) {
-        ItemMeta clickedItemMeta = clickedItemStack.getItemMeta();
-
-        PersistentDataContainer clickedItemContainer = clickedItemMeta.getPersistentDataContainer();
-
-        clickedItemContainer.set(this._clickedShulkerKey, PersistentDataType.STRING, player.getUniqueId().toString());
-
-        clickedItemStack.setItemMeta(clickedItemMeta);
-
+    private boolean IsOwnerOfEnderChest(Player player, Inventory clickedInventory, ItemStack clickedItemStack, int clickedSlot) {
+        if (!player.getEnderChest().equals(clickedInventory)) return false;
 
         ItemStack potentiallyClickedItem = player.getEnderChest().getItem(clickedSlot);
 
-        if (potentiallyClickedItem == null) {
-            clickedItemContainer.remove(this._clickedShulkerKey);
+        if (potentiallyClickedItem == null) return false;
 
-            clickedItemStack.setItemMeta(clickedItemMeta);
-            return false;
-        }
-
-        ItemMeta potentiallyClickedItemMeta = potentiallyClickedItem.getItemMeta();
-
-        PersistentDataContainer potentiallyClickedItemContainer = potentiallyClickedItemMeta.getPersistentDataContainer();
-
-        boolean isOwner = false;
-
-        if (potentiallyClickedItemContainer.has(this._clickedShulkerKey, PersistentDataType.STRING)) {
-            String uuid = potentiallyClickedItemContainer.get(this._clickedShulkerKey, PersistentDataType.STRING);
-
-            isOwner = uuid.equalsIgnoreCase(player.getUniqueId().toString());
-        }
-
-        clickedItemContainer.remove(this._clickedShulkerKey);
-
-        clickedItemStack.setItemMeta(clickedItemMeta);
-
-        return isOwner;
+        return potentiallyClickedItem == clickedItemStack || potentiallyClickedItem.equals(clickedItemStack);
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -216,7 +180,7 @@ public class ShulkerOpenCloseListener implements Listener {
 
         if (!this._openShulker.GetShulkerActions().IsOpenShulker(shulkerBox, event.getPlayer())) return;
 
-        boolean enderChest = this._openShulker.GetShulkerActions().HasOpenShulkerInEnderChest((Player) event.getPlayer());
+        boolean enderChest = this._openShulker.GetShulkerActions().HasOpenShulkerInEnderChest(event.getPlayer());
 
         Container container = this._openShulker.GetShulkerActions().GetShulkerHoldingContainer(event.getPlayer());
 
@@ -246,19 +210,23 @@ public class ShulkerOpenCloseListener implements Listener {
 
     @EventHandler
     public void OnShulkerInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) return;
+
         if (event.getInventory().getType() != InventoryType.SHULKER_BOX) return;
 
-        if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox((Player) event.getPlayer())) return;
+        Player player = (Player) event.getPlayer();
 
-        ItemStack itemStack = this._openShulker.GetShulkerActions().SearchShulkerBox((Player) event.getPlayer());
+        if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox(player)) return;
+
+        ItemStack itemStack = this._openShulker.GetShulkerActions().SearchShulkerBox(player);
 
         if (itemStack == null) return;
 
-        boolean enderChest = this._openShulker.GetShulkerActions().HasOpenShulkerInEnderChest((Player) event.getPlayer());
+        boolean enderChest = this._openShulker.GetShulkerActions().HasOpenShulkerInEnderChest(player);
 
-        Container container = this._openShulker.GetShulkerActions().GetShulkerHoldingContainer((Player) event.getPlayer());
+        Container container = this._openShulker.GetShulkerActions().GetShulkerHoldingContainer(player);
 
-        this._openShulker.GetShulkerActions().SaveShulkerBox(itemStack, event.getInventory(), (Player) event.getPlayer());
+        this._openShulker.GetShulkerActions().SaveShulkerBox(itemStack, event.getInventory(), player);
 
         this.ReopenInventory(enderChest, container, event.getPlayer());
     }

--- a/src/main/java/me/entity303/openshulker/listener/ShulkerReadOnlyListener.java
+++ b/src/main/java/me/entity303/openshulker/listener/ShulkerReadOnlyListener.java
@@ -16,11 +16,15 @@ public class ShulkerReadOnlyListener implements Listener {
 
     @EventHandler
     public void OnShulkerInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+
         if (event.getView().getTopInventory().getType() != InventoryType.SHULKER_BOX) return;
 
-        if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox((Player) event.getWhoClicked())) return;
+        Player player = (Player) event.getWhoClicked();
 
-        if (event.getWhoClicked().hasPermission("openshulker.write")) return;
+        if (!this._openShulker.GetShulkerActions().HasOpenShulkerBox(player)) return;
+
+        if (player.hasPermission("openshulker.write")) return;
 
         event.setCancelled(true);
     }

--- a/src/main/java/me/entity303/openshulker/util/SchedulerUtil.java
+++ b/src/main/java/me/entity303/openshulker/util/SchedulerUtil.java
@@ -1,0 +1,70 @@
+package me.entity303.openshulker.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+public final class SchedulerUtil {
+    private SchedulerUtil() {
+    }
+
+    public static void RunEntityLater(Plugin plugin, Entity entity, Runnable task, long delayTicks) {
+        if (delayTicks <= 0) {
+            if (TryRunEntity(plugin, entity, task)) return;
+
+            Bukkit.getScheduler().runTask(plugin, task);
+            return;
+        }
+
+        if (TryRunEntityLater(plugin, entity, task, delayTicks)) return;
+
+        Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
+    }
+
+    private static boolean TryRunEntity(Plugin plugin, Entity entity, Runnable task) {
+        try {
+            Object scheduler = GetEntityScheduler(entity);
+            Method run = scheduler.getClass().getMethod("run", Plugin.class, Consumer.class, Runnable.class);
+
+            Consumer<Object> scheduledTask = ignored -> task.run();
+            Runnable retired = () -> {
+            };
+
+            run.invoke(scheduler, plugin, scheduledTask, retired);
+            return true;
+        } catch (NoSuchMethodException ignored) {
+            return false;
+        } catch (Throwable throwable) {
+            plugin.getLogger().warning("Failed to schedule entity task, falling back to Bukkit scheduler: " + throwable.getMessage());
+            return false;
+        }
+    }
+
+    private static boolean TryRunEntityLater(Plugin plugin, Entity entity, Runnable task, long delayTicks) {
+        try {
+            Object scheduler = GetEntityScheduler(entity);
+            Method runDelayed = scheduler.getClass()
+                                         .getMethod("runDelayed", Plugin.class, Consumer.class, Runnable.class, long.class);
+
+            Consumer<Object> scheduledTask = ignored -> task.run();
+            Runnable retired = () -> {
+            };
+
+            runDelayed.invoke(scheduler, plugin, scheduledTask, retired, delayTicks);
+            return true;
+        } catch (NoSuchMethodException ignored) {
+            return false;
+        } catch (Throwable throwable) {
+            plugin.getLogger().warning("Failed to schedule entity task, falling back to Bukkit scheduler: " + throwable.getMessage());
+            return false;
+        }
+    }
+
+    private static Object GetEntityScheduler(Entity entity) throws Exception {
+        Method getScheduler = entity.getClass().getMethod("getScheduler");
+        return getScheduler.invoke(entity);
+    }
+}

--- a/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
+++ b/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
@@ -1,6 +1,7 @@
 package me.entity303.openshulker.util;
 
 import me.entity303.openshulker.OpenShulker;
+import me.entity303.openshulker.hooks.ChestSortHook;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.Container;
@@ -13,6 +14,9 @@ import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ShulkerActions {
     private final NamespacedKey _openShulkerKey;
@@ -49,7 +53,7 @@ public class ShulkerActions {
         container.remove(this._openShulkerLocationKey);
 
         try {
-            player.playSound(player, Sound.valueOf(this._openShulker.getConfig().getString("CloseSound")), 1F, 1F);
+            player.playSound(player.getLocation(), Sound.valueOf(this._openShulker.getConfig().getString("CloseSound")), 1F, 1F);
         } catch (Throwable ignored) {
             //Ignore the exception, it's probably just a message about not being able to find the correct sound
             //We have an info message in OpenShulker#onEnable for this
@@ -177,6 +181,51 @@ public class ShulkerActions {
         return this.IsOpenShulker(itemStack, null);
     }
 
+    public boolean IsShulkerBox(ItemStack itemStack) {
+        if (itemStack == null) return false;
+
+        if (itemStack.getType() == Material.AIR) return false;
+
+        return itemStack.getType().name().contains(Material.SHULKER_BOX.name());
+    }
+
+    public boolean CanInputIntoShulkerBox(Player player, ItemStack shulkerBoxStack, ItemStack itemStack) {
+        if (!player.hasPermission("openshulker.write")) return false;
+
+        if (!this.IsShulkerBox(shulkerBoxStack)) return false;
+
+        if (itemStack == null) return false;
+
+        if (itemStack.getType() == Material.AIR) return false;
+
+        if (this.IsShulkerBox(itemStack)) return false;
+
+        if (shulkerBoxStack.getAmount() != 1) return false;
+
+        if (!(shulkerBoxStack.getItemMeta() instanceof BlockStateMeta)) return false;
+
+        BlockStateMeta blockStateMeta = (BlockStateMeta) shulkerBoxStack.getItemMeta();
+
+        return blockStateMeta.getBlockState() instanceof ShulkerBox;
+    }
+
+    public ItemStack InputItemIntoShulkerBox(ItemStack shulkerBoxStack, ItemStack itemStack) {
+        BlockStateMeta blockStateMeta = (BlockStateMeta) shulkerBoxStack.getItemMeta();
+        ShulkerBox shulkerBox = (ShulkerBox) blockStateMeta.getBlockState();
+        Inventory inventory = shulkerBox.getInventory();
+
+        HashMap<Integer, ItemStack> leftovers = inventory.addItem(itemStack.clone());
+
+        blockStateMeta.setBlockState(shulkerBox);
+        shulkerBoxStack.setItemMeta(blockStateMeta);
+
+        if (leftovers.isEmpty()) return null;
+
+        for (Map.Entry<Integer, ItemStack> entry : leftovers.entrySet()) return entry.getValue();
+
+        return null;
+    }
+
     public boolean AttemptToOpenShulkerBox(Player player) {
         ItemStack itemStack = player.getInventory().getItemInMainHand();
 
@@ -214,9 +263,11 @@ public class ShulkerActions {
 
         container.set(this._openShulkerKey, PersistentDataType.STRING, player.getUniqueId().toString());
 
-        Inventory inventory = Bukkit.createInventory(null, InventoryType.SHULKER_BOX);
+        String inventoryTitle = meta.hasDisplayName() ? meta.getDisplayName() : null;
+        Inventory inventory = inventoryTitle == null ? Bukkit.createInventory(null, InventoryType.SHULKER_BOX) : Bukkit.createInventory(null, InventoryType.SHULKER_BOX, inventoryTitle);
 
-        PersistentDataContainer playerContainer = player.getPersistentDataContainer();
+        if (this._openShulker._hookChestSort) ChestSortHook.SetUnsortable(inventory);
+
         Bukkit.getScheduler().runTaskLater(this._openShulker, () -> {
             inventory.setContents(shulker.getInventory().getContents());
 
@@ -224,7 +275,7 @@ public class ShulkerActions {
         }, this._openShulker.getConfig().getLong("WaitSecondsBeforeOpen", 0) * 20);
 
         try {
-            player.playSound(player, Sound.valueOf(this._openShulker.getConfig().getString("OpenSound")), 1F, 1F);
+            player.playSound(player.getLocation(), Sound.valueOf(this._openShulker.getConfig().getString("OpenSound")), 1F, 1F);
         } catch (Throwable ignored) {
             //Ignore the exception, it's probably just a message about not being able to find the correct sound
             //We have an info message in OpenShulker#onEnable for this

--- a/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
+++ b/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
@@ -287,7 +287,7 @@ public class ShulkerActions {
         String inventoryTitle = meta.hasDisplayName() ? meta.getDisplayName() : null;
         Inventory inventory = inventoryTitle == null ? Bukkit.createInventory(null, InventoryType.SHULKER_BOX) : Bukkit.createInventory(null, InventoryType.SHULKER_BOX, inventoryTitle);
 
-        if (this._openShulker._hookChestSort) ChestSortHook.SetUnsortable(inventory);
+        if (this._openShulker._hookChestSort) ChestSortHook.SetUnsortable(inventory, this._openShulker._debugChestSort);
 
         SchedulerUtil.RunEntityLater(this._openShulker, player, () -> {
             if (!player.isOnline()) {
@@ -303,6 +303,9 @@ public class ShulkerActions {
             inventory.setContents(shulker.getInventory().getContents());
 
             player.openInventory(inventory);
+            if (this._openShulker._hookChestSort) {
+                ChestSortHook.SetUnsortable(player.getOpenInventory().getTopInventory(), this._openShulker._debugChestSort);
+            }
         }, this._openShulker.getConfig().getLong("WaitSecondsBeforeOpen", 0) * 20);
 
         try {

--- a/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
+++ b/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
@@ -289,7 +289,7 @@ public class ShulkerActions {
 
         if (this._openShulker._hookChestSort) ChestSortHook.SetUnsortable(inventory);
 
-        Bukkit.getScheduler().runTaskLater(this._openShulker, () -> {
+        SchedulerUtil.RunEntityLater(this._openShulker, player, () -> {
             if (!player.isOnline()) {
                 this.ClearOpenShulkerState(itemStack, player);
                 return;

--- a/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
+++ b/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
@@ -76,6 +76,7 @@ public class ShulkerActions {
         if (itemStack == null) {
             Bukkit.getLogger().severe("Player " + player.getName() + " (" + player.getUniqueId() + ") may have duped!");
             Bukkit.getLogger().severe("Currently viewing a shulker while not having an opened shulker!");
+            this.ClearPlayerOpenShulkerState(player);
             return false;
         }
 
@@ -89,6 +90,8 @@ public class ShulkerActions {
 
         if (dataContainer.has(this._openShulkerLocationKey, PersistentDataType.STRING)) {
             Container container = this.GetShulkerHoldingContainer(player);
+
+            if (container == null) return null;
 
             return this.SearchShulkerBox(container.getInventory(), player);
         }
@@ -124,13 +127,25 @@ public class ShulkerActions {
         if (!dataContainer.has(this._openShulkerLocationKey, PersistentDataType.STRING)) return null;
 
         String locationString = dataContainer.get(this._openShulkerLocationKey, PersistentDataType.STRING);
-        String[] locationStringArray = locationString.split(";");
+        if (locationString == null) return null;
 
-        double xCoordinate = Double.parseDouble(locationStringArray[0]);
-        double yCoordinate = Double.parseDouble(locationStringArray[1]);
-        double zCoordinate = Double.parseDouble(locationStringArray[2]);
+        String[] locationStringArray = locationString.split(";");
+        if (locationStringArray.length != 4) return null;
+
+        double xCoordinate;
+        double yCoordinate;
+        double zCoordinate;
+
+        try {
+            xCoordinate = Double.parseDouble(locationStringArray[0]);
+            yCoordinate = Double.parseDouble(locationStringArray[1]);
+            zCoordinate = Double.parseDouble(locationStringArray[2]);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
 
         World world = Bukkit.getWorld(locationStringArray[3]);
+        if (world == null) return null;
 
         Location location = new Location(world, xCoordinate, yCoordinate, zCoordinate);
 
@@ -158,6 +173,8 @@ public class ShulkerActions {
     }
 
     public boolean IsOpenShulker(ItemStack itemStack, Player player) {
+        if (itemStack == null) return false;
+
         ItemMeta meta = itemStack.getItemMeta();
 
         if (!(itemStack.getItemMeta() instanceof BlockStateMeta)) return false;
@@ -202,6 +219,8 @@ public class ShulkerActions {
 
         if (shulkerBoxStack.getAmount() != 1) return false;
 
+        if (this.IsOpenShulker(shulkerBoxStack)) return false;
+
         if (!(shulkerBoxStack.getItemMeta() instanceof BlockStateMeta)) return false;
 
         BlockStateMeta blockStateMeta = (BlockStateMeta) shulkerBoxStack.getItemMeta();
@@ -234,6 +253,8 @@ public class ShulkerActions {
 
     public boolean AttemptToOpenShulkerBox(Player player, ItemStack itemStack) {
         if (!player.hasPermission("openshulker.use")) return false;
+
+        if (itemStack == null) return false;
 
         if (itemStack.getAmount() <= 0) return false;
 
@@ -269,6 +290,16 @@ public class ShulkerActions {
         if (this._openShulker._hookChestSort) ChestSortHook.SetUnsortable(inventory);
 
         Bukkit.getScheduler().runTaskLater(this._openShulker, () -> {
+            if (!player.isOnline()) {
+                this.ClearOpenShulkerState(itemStack, player);
+                return;
+            }
+
+            if (!this.HasOpenShulkerBox(player)) {
+                this.ClearOpenShulkerState(itemStack, player);
+                return;
+            }
+
             inventory.setContents(shulker.getInventory().getContents());
 
             player.openInventory(inventory);
@@ -283,7 +314,26 @@ public class ShulkerActions {
         return true;
     }
 
+    private void ClearOpenShulkerState(ItemStack itemStack, Player player) {
+        if (itemStack != null && itemStack.getItemMeta() instanceof BlockStateMeta) {
+            ItemMeta meta = itemStack.getItemMeta();
+            meta.getPersistentDataContainer().remove(this._openShulkerKey);
+            itemStack.setItemMeta(meta);
+        }
+
+        this.ClearPlayerOpenShulkerState(player);
+    }
+
+    private void ClearPlayerOpenShulkerState(Player player) {
+        PersistentDataContainer container = player.getPersistentDataContainer();
+
+        container.remove(this._openShulkerKey);
+        container.remove(this._openShulkerLocationKey);
+    }
+
     public boolean AttemptToOpenShulkerBox(Player player, ItemStack itemStack, Location chest) {
+        if (chest == null || chest.getWorld() == null) return false;
+
         Block block = chest.getBlock();
 
         if (!(block.getState() instanceof Container)) return false;

--- a/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
+++ b/src/main/java/me/entity303/openshulker/util/ShulkerActions.java
@@ -67,15 +67,18 @@ public class ShulkerActions {
 
         if (!container.has(this._openShulkerKey, PersistentDataType.STRING)) {
             if (itemStack != null) {
-                Bukkit.getLogger().severe("Player " + player.getName() + " (" + player.getUniqueId() + ") may have duped!");
-                Bukkit.getLogger().severe("Found opened Shulker while not having a shulker open!");
+                this._openShulker.getLogger()
+                                 .warning("Recovered stale open shulker item state for " + player.getName() + " (" +
+                                          player.getUniqueId() + ").");
+                this.ClearOpenShulkerState(itemStack, player);
             }
             return false;
         }
 
         if (itemStack == null) {
-            Bukkit.getLogger().severe("Player " + player.getName() + " (" + player.getUniqueId() + ") may have duped!");
-            Bukkit.getLogger().severe("Currently viewing a shulker while not having an opened shulker!");
+            this._openShulker.getLogger()
+                             .warning("Recovered stale open shulker player state for " + player.getName() + " (" +
+                                      player.getUniqueId() + ").");
             this.ClearPlayerOpenShulkerState(player);
             return false;
         }
@@ -295,7 +298,14 @@ public class ShulkerActions {
                 return;
             }
 
-            if (!this.HasOpenShulkerBox(player)) {
+            ItemStack currentOpenShulker = this.SearchShulkerBox(player);
+
+            if (currentOpenShulker == null || !this.IsOpenShulker(currentOpenShulker, player)) {
+                this.ClearOpenShulkerState(itemStack, player);
+                return;
+            }
+
+            if (currentOpenShulker != itemStack && !currentOpenShulker.equals(itemStack)) {
                 this.ClearOpenShulkerState(itemStack, player);
                 return;
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,9 @@ OpenMethods:
 WaitSecondsBeforeOpen: 0
 OpenSound: "BLOCK_SHULKER_BOX_OPEN"
 CloseSound: "BLOCK_SHULKER_BOX_CLOSE"
+Hooks:
+  ChestSort: true
+  WorldGuard: true
 Messages:
   Prefix: "&8[&2OpenShulker&8] &7"
   CannotBreakContainer: "§cYou cannot break this container, since there's an opened shulker in it"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,7 +11,7 @@ Hooks:
   WorldGuard: true
 Messages:
   Prefix: "&8[&2OpenShulker&8] &7"
-  CannotBreakContainer: "§cYou cannot break this container, since there's an opened shulker in it"
+  CannotBreakContainer: "&cYou cannot break this container, since there's an opened shulker in it"
   OpenShulkerCommand:
     Syntax: "&cSyntax: &4/<LABEL> <Reload>"
     Reloaded: "The plugin was reloaded!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,11 +7,34 @@ WaitSecondsBeforeOpen: 0
 OpenSound: "BLOCK_SHULKER_BOX_OPEN"
 CloseSound: "BLOCK_SHULKER_BOX_CLOSE"
 Hooks:
+  # If ChestSort is installed and this is true, opened shulker inventories are marked as unsortable.
   ChestSort: true
+  # If true, OpenShulker logs a warning when ChestSort is installed but its API could not be used.
+  ChestSortDebug: false
+  # If WorldGuard is installed and this is true, shulkers inside protected containers can only be used where the player has container access.
+  # OpenShulker checks the WorldGuard flags chest-access and interact.
+  #
+  # WorldGuard ingame setup:
+  # 1. Select/create your region as usual.
+  # 2. Allow players to use shulkers in containers in that region:
+  #    /rg flag <region> chest-access allow
+  #    /rg flag <region> interact allow
+  # 3. Block players from changing shulkers in protected containers:
+  #    /rg flag <region> chest-access deny
+  #    /rg flag <region> interact deny
+  # 4. For the global region, use:
+  #    /rg flag __global__ chest-access deny
+  #    /rg flag __global__ interact deny
+  # 5. After changing this config value, reload OpenShulker:
+  #    /openshulker reload
+  #    /openshulker hooks
   WorldGuard: true
+# Ingame admin commands:
+# /openshulker reload - reloads this config
+# /openshulker hooks - shows if ChestSort/WorldGuard hooks are enabled and loaded
 Messages:
   Prefix: "&8[&2OpenShulker&8] &7"
   CannotBreakContainer: "&cYou cannot break this container, since there's an opened shulker in it"
   OpenShulkerCommand:
-    Syntax: "&cSyntax: &4/<LABEL> <Reload>"
+    Syntax: "&cSyntax: &4/<LABEL> <Reload|Hooks>"
     Reloaded: "The plugin was reloaded!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '${project.version}'
 main: me.entity303.openshulker.OpenShulker
 api-version: 1.14
 authors: [Entity303]
+softdepend: [ChestSort, WorldGuard]
 commands:
   openshulker:
     permission: "openshulker.admin"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: OpenShulker
 version: '${project.version}'
 main: me.entity303.openshulker.OpenShulker
 api-version: 1.14
+folia-supported: true
 authors: [Entity303]
 softdepend: [ChestSort, WorldGuard]
 commands:


### PR DESCRIPTION
Updated OpenShulker for Minecraft 26.2 while keeping api-version: 1.14 for backward compatibility.

Added direct item insertion into shulker boxes via right-click interactions.

Added optional ChestSort and WorldGuard integration.

Fixed protected-container interaction by no longer uncancelling PlayerInteractEvent.

Custom shulker display names are now used as the opened inventory title.

Details
Paper API updated to 26.2.build.31-alpha.
Java target remains Java 8 for old server compatibility.

Added softdepend: [ChestSort, WorldGuard].

Added config toggles:Hooks.ChestSort
Hooks.WorldGuard

ChestSort hook marks virtual shulker inventories as unsortable.

WorldGuard hook checks Flags.BUILD before opening/inputting shulkers from protected container inventories.

Right-click item input supports:item cursor on shulker box shulker box cursor on item

Prevents shulker-in-shulker insertion.

[OpenShulker-1.4.0.zip](https://github.com/user-attachments/files/29249248/OpenShulker-1.4.0.zip)

